### PR TITLE
Update for API changes

### DIFF
--- a/pushbullet.go
+++ b/pushbullet.go
@@ -47,7 +47,7 @@ type Device struct {
 		Model          string
 		AndroidVersion string `json:"android_version"`
 		SdkVersion     string `json:"sdk_version"`
-		AppVersion     string `json:"app_version"`
+		AppVersion     int    `json:"app_version"`
 		Nickname       string
 	}
 }


### PR DESCRIPTION
PushBullet recently changed the API endpoint from www.pushbullet.com/api to api.pushbullet.com/api.  This patch update the HOST variable to point to the new endpoint.

The JSON response has also changed slightly: AppVersion now appears to be coming back as an int, and we need to unpack it as such.
