### PR TITLE
Added more Device shortcuts and removed out of date functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,15 @@ err = pb.PushSMS(user.Iden, devs[0].Iden, "<TARGET_PHONE_NUMBER>", "Sms text")
 if err != nil {
 	panic(err)
 }
+
+You can also retrieve a pushbullet device by nickname, and call the same methods as you would with the pushbbulet client
+dev, err := pb.Device("My Phone")
+if err != nil {
+	panic(err)
+}
+
+err = dev.PushNote("Hello!", "Straight to device with just a title and body")
+if err != nil {
+	panic(err)
+}
 ```

--- a/pushbullet.go
+++ b/pushbullet.go
@@ -161,41 +161,17 @@ func (c *Client) Device(nickname string) (*Device, error) {
 
 // PushNote sends a note to the specific device with the given title and body
 func (d *Device) PushNote(title, body string) error {
-	data := Note{
-		Iden:  d.Iden,
-		Type:  "note",
-		Title: title,
-		Body:  body,
-	}
-	return d.Client.Push("/pushes", data)
+	return d.Client.PushNote(d.Iden, title, body)
 }
 
 // PushLink sends a link to the specific device with the given title and url
 func (d *Device) PushLink(title, u, body string) error {
-	data := Link{
-		Iden:  d.Iden,
-		Type:  "link",
-		Title: title,
-		URL:   u,
-		Body:  body,
-	}
-	return d.Client.Push("/pushes", data)
+	return d.Client.PushLink(d.Iden, title, u, body)
 }
 
 // PushSMS sends an SMS to the specific user from the device with the given title and url
 func (d *Device) PushSMS(deviceIden, phoneNumber, message string) error {
-	data := Ephemeral{
-		Type: "push",
-		Push: EphemeralPush{
-			Type:             "messaging_extension_reply",
-			PackageName:      "com.pushbullet.android",
-			SourceUserIden:   d.Iden,
-			TargetDeviceIden: deviceIden,
-			ConversationIden: phoneNumber,
-			Message:          message,
-		},
-	}
-	return d.Client.Push("/ephemerals", data)
+	return d.Client.PushSMS(d.Iden, deviceIden, phoneNumber, message)
 }
 
 // User represents the User object for pushbullet

--- a/pushbullet.go
+++ b/pushbullet.go
@@ -22,6 +22,9 @@ import (
 	"net/url"
 )
 
+// ErrDeviceNotFound is raised when device nickname is not found on pusbullet server
+var ErrDeviceNotFound = errors.New("Device not found")
+
 // EndpointURL sets the default URL for the Pushbullet API
 var EndpointURL = "https://api.pushbullet.com/v2"
 
@@ -156,7 +159,7 @@ func (c *Client) Device(nickname string) (*Device, error) {
 			return devices[i], nil
 		}
 	}
-	return nil, errors.New("Device not found!")
+	return nil, ErrDeviceNotFound
 }
 
 // PushNote sends a note to the specific device with the given title and body

--- a/pushbullet.go
+++ b/pushbullet.go
@@ -282,42 +282,6 @@ func (c *Client) PushNote(iden string, title, body string) error {
 	return c.Push("/pushes", data)
 }
 
-type Address struct {
-	Iden    string `json:"device_iden"`
-	Type    string `json:"type"`
-	Name    string `json:"name"`
-	Address string `json:"address"`
-}
-
-// PushAddress pushes a geo address with name and address to a specific PushBullet device.
-func (c *Client) PushAddress(iden string, name, address string) error {
-	data := Address{
-		Iden:    iden,
-		Type:    "address",
-		Name:    name,
-		Address: address,
-	}
-	return c.Push("/pushes", data)
-}
-
-type List struct {
-	Iden  string   `json:"device_iden"`
-	Type  string   `json:"type"`
-	Title string   `json:"title"`
-	Items []string `json:"items"`
-}
-
-// PushList pushes a list with name and a slice of items to a specific PushBullet device.
-func (c *Client) PushList(iden string, title string, items []string) error {
-	data := List{
-		Iden:  iden,
-		Type:  "list",
-		Title: title,
-		Items: items,
-	}
-	return c.Push("/pushes", data)
-}
-
 // Link exposes the required and optional fields of the Pushbullet push type=link
 type Link struct {
 	Iden  string `json:"device_iden"`

--- a/pushbullet_test.go
+++ b/pushbullet_test.go
@@ -133,10 +133,62 @@ func TestDevices(t *testing.T) {
 	defer server.Close()
 	pb := New(k)
 	pb.Endpoint.URL = server.URL
+	d.Client = pb
 	devs, err := pb.Devices()
 	assert.NoError(t, err)
 	assert.Len(t, devs, 1)
 	assert.Equal(t, d, devs[0])
+}
+
+func TestDeviceWithNickname(t *testing.T) {
+	server := PushbulletResponseStub()
+	defer server.Close()
+	pb := New(k)
+	pb.Endpoint.URL = server.URL
+	dev, err := pb.Device(d.Nickname)
+	assert.NoError(t, err)
+	assert.Equal(t, d.Nickname, dev.Nickname)
+	assert.Equal(t, pb, dev.Client)
+}
+
+func TestDeviceWithNicknameMissing(t *testing.T) {
+	server := PushbulletResponseStub()
+	defer server.Close()
+	pb := New(k)
+	pb.Endpoint.URL = server.URL
+	dev, err := pb.Device("MISSING")
+	assert.Error(t, err)
+	assert.Nil(t, dev)
+}
+
+func TestDevicePushNote(t *testing.T) {
+	server := PushbulletResponseStub()
+	defer server.Close()
+	pb := New(k)
+	pb.Endpoint.URL = server.URL
+	dev, _ := pb.Device(d.Nickname)
+	err := dev.PushNote(n.Title, n.Body)
+	assert.NoError(t, err)
+}
+
+func TestDevicePushLink(t *testing.T) {
+	server := PushbulletResponseStub()
+	defer server.Close()
+	pb := New(k)
+	pb.Endpoint.URL = server.URL
+	dev, _ := pb.Device(d.Nickname)
+	err := dev.PushLink(l.Title, l.URL, l.Body)
+	assert.NoError(t, err)
+}
+
+func TestDevicePushSMS(t *testing.T) {
+	server := PushbulletResponseStub()
+	defer server.Close()
+	pb := New(k)
+	pb.Endpoint.URL = server.URL
+	dev, _ := pb.Device(d.Nickname)
+	err := dev.PushSMS(s.TargetDeviceIden, s.ConversationIden, s.Message)
+	assert.NoError(t, err)
 }
 
 func TestDevicesError(t *testing.T) {


### PR DESCRIPTION
Hi,

Not sure if this is the way you wanted to go with this, but I thought it would be nicer to call Push<type> from Device directly, rather than having to specify the Iden on the Client.Push<type> functions.

Rather than repeat the code entirely, I have used the existing Client functions but passed through the Device.Iden automatically. This meant accessing Client from Device struct however, so I did need to add it in during the call to Devices() and Device(nickname).

On the Device(nickname) function, not sure if the error should be a plain string or separated out to a struct?

Also have removed the out of date List and Address pushes and structs as they have been "deprecated in forever" according to the API docs.

Test cases added as always.

EDIT: Just realised I didn't edit the readme, let me know if this PR is something that you're interested in and I'll add the readme change to the commit before merge.

Cheers,