### PR TITLE
Add channel/subscription functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ go-pushbullet
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](http://opensource.org/licenses/MIT)
 
 Simple Go client for [Pushbullet](http://pushbullet.com), a webservice to push
-lists, addresses, links and more to your Android devices.
+links, notes and more to your Android devices.
 
 Documentation available under: http://godoc.org/github.com/xconstruct/go-pushbullet
 
@@ -38,8 +38,10 @@ err = pb.PushSMS(user.Iden, devs[0].Iden, "<TARGET_PHONE_NUMBER>", "Sms text")
 if err != nil {
 	panic(err)
 }
+```
 
-You can also retrieve a pushbullet device by nickname, and call the same methods as you would with the pushbbulet client
+You can also retrieve a pushbullet device by nickname, and call the same methods as you would with the pushbullet client  
+```go
 dev, err := pb.Device("My Phone")
 if err != nil {
 	panic(err)
@@ -49,8 +51,10 @@ err = dev.PushNote("Hello!", "Straight to device with just a title and body")
 if err != nil {
 	panic(err)
 }
+```
 
-Channels are also supported in a similar manner
+Channels are also supported in a similar manner  
+```go
 subs, err := pb.Subscriptions()
 if err != nil {
 	panic(err)

--- a/README.md
+++ b/README.md
@@ -49,4 +49,26 @@ err = dev.PushNote("Hello!", "Straight to device with just a title and body")
 if err != nil {
 	panic(err)
 }
+
+Channels are also supported in a similar manner
+subs, err := pb.Subscriptions()
+if err != nil {
+	panic(err)
+}
+
+err = pb.PushNoteToChannel(subs[0].Channel.Tag, "Hello!", "Hi from go-pushbullet!")
+if err != nil {
+	panic(err)
+}
+
+sub, err := pb.Subscription("MyChannelTag")
+if err != nil {
+	panic(err)
+}
+
+err = sub.PushNote("Hello!", "Straight to Channel with just a title and body")
+if err != nil {
+	panic(err)
+}
+
 ```

--- a/pushbullet.go
+++ b/pushbullet.go
@@ -266,6 +266,17 @@ func (c *Client) PushNote(iden string, title, body string) error {
 	return c.Push("/pushes", data)
 }
 
+// PushNoteToChannel pushes a note with title and body to a specific PushBullet channel.
+func (c *Client) PushNoteToChannel(tag string, title, body string) error {
+	data := Note{
+		Tag:   tag,
+		Type:  "note",
+		Title: title,
+		Body:  body,
+	}
+	return c.Push("/pushes", data)
+}
+
 // Link exposes the required and optional fields of the Pushbullet push type=link
 type Link struct {
 	Iden  string `json:"device_iden,omitempty"`
@@ -280,6 +291,18 @@ type Link struct {
 func (c *Client) PushLink(iden, title, u, body string) error {
 	data := Link{
 		Iden:  iden,
+		Type:  "link",
+		Title: title,
+		URL:   u,
+		Body:  body,
+	}
+	return c.Push("/pushes", data)
+}
+
+// PushLinkToChannel pushes a link with a title and url to a specific PushBullet device.
+func (c *Client) PushLinkToChannel(tag, title, u, body string) error {
+	data := Link{
+		Tag:   tag,
 		Type:  "link",
 		Title: title,
 		URL:   u,
@@ -373,15 +396,15 @@ func (c *Client) Subscriptions() ([]*Subscription, error) {
 	return subscriptions, nil
 }
 
-// Subscription fetches an subscription with a given channel_name from PushBullet.
-func (c *Client) Subscription(name string) (*Subscription, error) {
+// Subscription fetches an subscription with a given channel tag from PushBullet.
+func (c *Client) Subscription(tag string) (*Subscription, error) {
 	subs, err := c.Subscriptions()
 	if err != nil {
 		return nil, err
 	}
 
 	for i := range subs {
-		if subs[i].Channel.Name == name {
+		if subs[i].Channel.Tag == tag {
 			subs[i].Client = c
 			return subs[i], nil
 		}
@@ -391,23 +414,10 @@ func (c *Client) Subscription(name string) (*Subscription, error) {
 
 // PushNote sends a note to the specific Channel with the given title and body
 func (s *Subscription) PushNote(title, body string) error {
-	data := Note{
-		Tag:   s.Channel.Tag,
-		Type:  "note",
-		Title: title,
-		Body:  body,
-	}
-	return s.Client.Push("/pushes", data)
+	return s.Client.PushNoteToChannel(s.Channel.Tag, title, body)
 }
 
-// PushLink sends a link to the specific Channel with the given title and url
+// PushNote sends a link to the specific Channel with the given title, url and body
 func (s *Subscription) PushLink(title, u, body string) error {
-	data := Link{
-		Tag:   s.Channel.Tag,
-		Type:  "link",
-		Title: title,
-		URL:   u,
-		Body:  body,
-	}
-	return s.Client.Push("/pushes", data)
+	return s.Client.PushLinkToChannel(s.Channel.Tag, title, u, body)
 }

--- a/pushbullet_test.go
+++ b/pushbullet_test.go
@@ -310,6 +310,24 @@ func TestPushNote(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestPushLinkToChannel(t *testing.T) {
+	server := PushbulletResponseStub()
+	defer server.Close()
+	pb := New(k)
+	pb.Endpoint.URL = server.URL
+	err := pb.PushLinkToChannel(sub.Channel.Tag, l.Title, l.URL, l.Body)
+	assert.NoError(t, err)
+}
+
+func TestPushNoteToChannel(t *testing.T) {
+	server := PushbulletResponseStub()
+	defer server.Close()
+	pb := New(k)
+	pb.Endpoint.URL = server.URL
+	err := pb.PushNoteToChannel(sub.Channel.Tag, n.Title, n.Body)
+	assert.NoError(t, err)
+}
+
 func TestPushSMS(t *testing.T) {
 	server := PushbulletResponseStub()
 	defer server.Close()
@@ -358,9 +376,9 @@ func TestSubscriptionWithName(t *testing.T) {
 	defer server.Close()
 	pb := New(k)
 	pb.Endpoint.URL = server.URL
-	sub, err := pb.Subscription(c.Name)
+	sub, err := pb.Subscription(c.Tag)
 	assert.NoError(t, err)
-	assert.Equal(t, c.Name, sub.Channel.Name)
+	assert.Equal(t, c.Tag, sub.Channel.Tag)
 	assert.Equal(t, pb, sub.Client)
 }
 
@@ -379,7 +397,7 @@ func TestSubscriptionPushNote(t *testing.T) {
 	defer server.Close()
 	pb := New(k)
 	pb.Endpoint.URL = server.URL
-	sub, _ := pb.Subscription(sub.Channel.Name)
+	sub, _ := pb.Subscription(sub.Channel.Tag)
 	err := sub.PushNote(n.Title, n.Body)
 	assert.NoError(t, err)
 }
@@ -389,7 +407,7 @@ func TestSubscriptionPushLink(t *testing.T) {
 	defer server.Close()
 	pb := New(k)
 	pb.Endpoint.URL = server.URL
-	sub, _ := pb.Subscription(sub.Channel.Name)
+	sub, _ := pb.Subscription(sub.Channel.Tag)
 	err := sub.PushLink(l.Title, l.URL, l.Body)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
Added some channel functionality similar to what was added for Device. Ran into the problem that PushNote is really tailored for pushing to devices as it requires an Iden. According to the docs, there are five types of push: 
- device_iden - Send the push to a specific device
- email - Send the push to this email address
- channel_tag - Send the push to all subscribers to your channel that has this tag.
- client_iden - Send the push to all users who have granted access to your OAuth client that has this iden
- Each push has a target, if you don't specify a target, we will broadcast it to all of the user's devices.

I'm therefore wondering if we should use PushNote as the last option and create a new function for PushNoteToDevice which is the current function. I have created a PushNoteToChannel which seems to be the idiomatic way of writing these functions in go, as I say, still learning go so happy to be corrected!

Used same implementation of Device so each Subscription has access to the Client. Also not sure if they should be called Subscription or Channels. Even Pushbullet don't seem to make this clear in the docs, you push to a channel but a channel object is inside the subscription object. I've kept with subscription as that is the name of the end point too but don't know if it makes more sense to call these channels.

Cheers!